### PR TITLE
Assignment 1

### DIFF
--- a/Assignment_1.js
+++ b/Assignment_1.js
@@ -1,0 +1,61 @@
+/*Text Index*/
+db.student.createIndex({name: "text", description: "text"},
+{
+"createdCollectionAutomatically" : false,
+"numIndexesBefore" : 1,
+"numIndexsAfter" : 2,
+"ok": 1
+})
+  then give db.student.getindexes()
+/*o/p 
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student_id: 777777 }, name: 'student_id_777777' },
+  { v: 2, key: { student_id: 1 }, name: 'student_id_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  },
+  {
+    v: 2,
+    key: { _fts: 'text', _ftsx: 1 },
+    name: 'name_text_description_text',
+    weights: { description: 1, name: 1 },
+    default_language: 'english',
+    language_override: 'language',
+    textIndexVersion: 3
+  }
+] 
+*/
+    //HashIndex
+db.student.createIndex({_id: "hashed"})
+>_id_hashed
+db.student.getIndexes()
+/*o/p:
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student_id: 777777 }, name: 'student_id_777777' },
+  { v: 2, key: { student_id: 1 }, name: 'student_id_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  },
+  {
+    v: 2,
+    key: { _fts: 'text', _ftsx: 1 },
+    name: 'name_text_description_text',
+    weights: { description: 1, name: 1 },
+    default_language: 'english',
+    language_override: 'language',
+    textIndexVersion: 3
+  },
+  { v: 2, key: { _id: 'hashed' }, name: '_id_hashed' }
+]*/
+
+    

--- a/Assignment_1.js
+++ b/Assignment_1.js
@@ -58,4 +58,34 @@ db.student.getIndexes()
   { v: 2, key: { _id: 'hashed' }, name: '_id_hashed' }
 ]*/
 
-    
+  //wildcard Index
+db.student.createIndex(
+{"fieldName.$**": 1 },
+  { name: "wildcard_index"}
+);
+wildcard_index
+db.student.getIndexes()
+/*o/p: 
+[
+  { v: 2, key: { _id: 1 }, name: '_id_' },
+  { v: 2, key: { student_id: 223344 }, name: 'student_id_223344' },
+  { v: 2, key: { student_id: 777777 }, name: 'student_id_777777' },
+  { v: 2, key: { student_id: 1 }, name: 'student_id_1' },
+  {
+    v: 2,
+    key: { score: '2dsphere' },
+    name: 'score_2dsphere',
+    '2dsphereIndexVersion': 3
+  },
+  {
+    v: 2,
+    key: { _fts: 'text', _ftsx: 1 },
+    name: 'name_text_description_text',
+    weights: { description: 1, name: 1 },
+    default_language: 'english',
+    language_override: 'language',
+    textIndexVersion: 3
+  },
+  { v: 2, key: { _id: 'hashed' }, name: '_id_hashed' },
+  { v: 2, key: { 'fieldName.$**': 1 }, name: 'wildcard_index' }
+] */


### PR DESCRIPTION
1. Text Index: MongoDB supports query operations that perform a text search of string content. Text indexing allows us to find the string content in the specified collection. It can include any field that contains string content or an array of string items. A collection can contain, at most, one text index. You are allowed to use the text index in the compound index.  
Syntax: db.<collection>.createIndex( { <field>: “text”} ) 
Example: 
<img width="1710" alt="Text Index" src="https://github.com/LathaPutireddy/DB/assets/157643789/d5aa223a-a698-470e-88bd-62663ae00746">

2. MultiKey Index: MongoDB uses the multikey indexes to index the values stored in arrays. When we index a field that holds an array value then MongoDB automatically creates a separate index of each and every value present in that array. Using these multikey indexes we can easily find a document that contains an array by matching the items. In MongoDB, you don’t need to explicitly specify the multikey index because MongoDB automatically determines whether to create a multikey index if the indexed field contains an array value. 
Syntax:db.<collection>.createIndex( { <field>: <type>} )
Example: 
<img width="1710" alt="MultiKey Index" src="https://github.com/LathaPutireddy/DB/assets/157643789/8026de0d-a0c0-4653-9abb-4833f0bd7727">

4. Hash Index: To maintain the entries with hashes of the values of the indexed field (mostly the _id field in all collections), we use the hash index. This kind of index is mainly required for the even distribution of data via sharing. Hashed keys help partition the data across the shared cluster.
Syntax: db.<collection>.createIndex( { _id: “hashed” } )
Example:
<img width="1710" alt="Hash Index" src="https://github.com/LathaPutireddy/DB/assets/157643789/31f7b5af-e06c-4ecc-a6e1-3c8cbe2e9604">


5. WildCard Index: MongoDB supports creating indexes either on a field or set of fields, and if the set of fields is mentioned, it is called a Wildcard Index. Generally, the wildcard index does not include the _id field, but if you want to include the _id field in the wildcard index, then you have to define it explicitly. MongoDB allows you to create multiple wildcard indexes in the given collection. Wildcard indexes support queries for unknown or arbitrary fields.
Syntax: db.<collection>.createIndex( { “field.$**”:1 } )
Example: 
<img width="1710" alt="Wild Card Index" src="https://github.com/LathaPutireddy/DB/assets/157643789/e8fa3107-6697-4cfa-ac8e-754d378a0493">
